### PR TITLE
add cpu_model to nxf_trace_mac

### DIFF
--- a/modules/nextflow/src/main/resources/nextflow/executor/command-trace.txt
+++ b/modules/nextflow/src/main/resources/nextflow/executor/command-trace.txt
@@ -127,6 +127,7 @@ nxf_write_trace() {
     echo "nextflow.trace/v2"           > $trace_file
     echo "realtime=$wall_time"         >> $trace_file
     echo "%cpu=$ucpu"                  >> $trace_file
+    echo "cpu_model=$cpu_model"        >> $trace_file
     echo "rchar=${io_stat1[0]}"        >> $trace_file
     echo "wchar=${io_stat1[1]}"        >> $trace_file
     echo "syscr=${io_stat1[2]}"        >> $trace_file
@@ -144,6 +145,7 @@ nxf_trace_mac() {
     local end_millis=$(nxf_date)
     local wall_time=$((end_millis-start_millis))
     local ucpu=''
+    local cpu_model=''
     local io_stat1=('' '' '' '' '' '')
     nxf_write_trace
 }


### PR DESCRIPTION
When we run a task in a MAC system, most of the metrics are not reported. We see a warning “WARN: Task runtime metrics are not reported when using macOS without a container engine”
That’s why I set cpu_model to an empty string in nxf_trace_mac()